### PR TITLE
added image versioning along with related config options etc

### DIFF
--- a/classes/casset.php
+++ b/classes/casset.php
@@ -75,6 +75,11 @@ class Casset {
 	protected static $combine_default = false;
 
 	/**
+	 * @var bool Whether to version images
+	 */
+	protected static $version_images = false;
+
+	/**
 	 * @var bool Whether to show comments above the <script>/<link> tags showing
 	 *           which files have been minified into that file.
 	 */
@@ -123,6 +128,8 @@ class Casset {
 
 		static::$min_default = \Config::get('casset.min', static::$min_default);
 		static::$combine_default = \Config::get('casset.combine', static::$combine_default);
+
+		static::$version_images = \Config::get('casset.version_images', static::$version_images);
 
 
 		$group_sets = \Config::get('casset.groups', array());
@@ -818,11 +825,27 @@ class Casset {
 			foreach ($image_paths as $image_path)
 			{
 				$base = (strpos($image_path, '//') === false) ? static::$asset_url : '';
+				$image_path = (static::$version_images) ? static::version_img($image_path) : $image_path;
 				$attr['src'] = $base.$image_path;
 				$ret .= html_tag('img', $attr);
 			}
 		}
 		return $ret;
+	}
+
+	/**
+	 * Returns given img with modified path to include file modified time.
+	 * Requires .htaccess in public route to make this work...
+	 *
+	 * @param string $image_path
+	 * @return void
+	 * @author Lee Overy
+	 */
+	public static function version_img($image_path)
+	{
+		$path 	= pathinfo($image_path);
+		$mtime 	= '.'.filemtime(DOCROOT.$image_path).'.';
+		return str_replace('.'.$path['extension'], $mtime, $image_path.$path['extension']);
 	}
 
 	/**

--- a/config/casset.php
+++ b/config/casset.php
@@ -101,6 +101,32 @@ return array(
 	 */
 	'combine' => true,
 
+	/*
+	 * Whether to version images or not.
+	 * NOTE: If this is TRUE then you need to include the following in your
+	 * .htaccess file (or equivalent).
+	 *
+	 * # http://example.com/assets/img/test.1298892196.jpeg
+	 * RewriteRule ^(.*)\/(.+)\.([0-9]+)\.(js|css|jpg|jpeg|gif|png|php)$ $1/$2.$4 [L]
+	 *
+	 * This has to go above the index.php removal lines if you are using that
+	 * feature. If you are it should look something like this:
+	 *
+		<IfModule mod_rewrite.c>
+			RewriteBase /
+
+			# http://example.com/assets/img/test.1298892196.jpeg
+			RewriteRule ^(.*)\/(.+)\.([0-9]+)\.(js|css|jpg|jpeg|gif|png)$ $1/$2.$4 [L]
+
+		    RewriteCond %{REQUEST_FILENAME} !-f
+		    RewriteCond %{REQUEST_FILENAME} !-d
+
+		    RewriteRule ^(.*)$ index.php/$1 [L]
+		</IfModule>
+	 *
+	*/
+	'version_images' => false,
+
 	/**
 	 * When minifying, whether to show the files names in each combined
 	 * file in a comment before the tag to the file.


### PR DESCRIPTION
Hi,

Im sorry if Ive done this wrong as its my first pull request. I rebased my feature branch onto the tip of develop and have pushed that to my repo.

Basically Ive added versioning for images. This is something I use quite a lot as my images are big so I cache them for 10 years (!). If the image is changed then the filename will automatically change too and hence will force the browser to re-request it.

Obviously this needs a .htaccess modification so Ive left the default to false so it doesnt break anything. The necessary lines for the .htaccess file are included in the casset config file.

Also you could pass in a bool param to Casset::img to force versioning on a per-img basis but I didnt add this at this stage.

Hope thats helpful. Let me know what you think.

Lee
(leekudos)
