### PR TITLE
Suggestion: render inline needlessly creates multiple tags

### DIFF
--- a/classes/casset.php
+++ b/classes/casset.php
@@ -1157,12 +1157,7 @@ class Casset {
 		else
 			$attr = array();
 
-		$ret = '';
-		foreach (static::$inline_assets['js'] as $content)
-		{
-			$ret .= html_tag('script', $attr, PHP_EOL.$content.PHP_EOL).PHP_EOL;
-		}
-		return $ret;
+		return html_tag('script', $attr, PHP_EOL.implode(PHP_EOL, static::$inline_assets['js']).PHP_EOL).PHP_EOL;
 	}
 
 	/**
@@ -1180,12 +1175,7 @@ class Casset {
 		else
 			$attr = array();
 
-		$ret = '';
-		foreach (static::$inline_assets['css'] as $content)
-		{
-			$ret .= html_tag('style', $attr, PHP_EOL.$content.PHP_EOL).PHP_EOL;
-		}
-		return $ret;
+		return html_tag('style', $attr, PHP_EOL.implode(PHP_EOL, static::$inline_assets['css']).PHP_EOL).PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
Changed both functions to render a single tag per render call.

I think the output is cleaner as a result
